### PR TITLE
Set requests on sign up and sign in

### DIFF
--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
@@ -100,6 +100,7 @@ public class GraphQLMutationService {
                         .managePsa(false)
                         .sequencesPlayed(0)
                         .build())
+                .requests(new ArrayList<>())
                 .stats(Stat.builder()
                         .jukebox(new ArrayList<>())
                         .page(new ArrayList<>())

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLQueryService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLQueryService.java
@@ -54,6 +54,9 @@ public class GraphQLQueryService {
                 if(show.getPreferences().getViewerControlMode() == null) {
                     show.getPreferences().setViewerControlMode(ViewerControlMode.JUKEBOX);
                 }
+                if(CollectionUtils.isEmpty(show.getRequests())) {
+                    show.setRequests(new ArrayList<>());
+                }
                 this.showRepository.save(show);
                 show.setServiceToken(this.authUtil.signJwt(show));
                 return show;


### PR DESCRIPTION
Fixed by setting requests to an empty array when signing up. To fix existing accounts with the same issue, also setting requests as an empty list when signing in (only if it doesn't exist).