### PR TITLE
Add viewerPageViewOnly field to GraphQL schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>com.github.Remote-Falcon</groupId>
             <artifactId>remote-falcon-library</artifactId>
-            <version>9cb8f5ade2</version>
+            <version>685018c867</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.quarkus</groupId>

--- a/src/main/resources/graphql/inputs.graphqls
+++ b/src/main/resources/graphql/inputs.graphqls
@@ -46,6 +46,7 @@ input UserProfileInput {
 
 input PreferenceInput {
     viewerControlEnabled: Boolean
+    viewerPageViewOnly: Boolean
     viewerControlMode: String
     resetVotes: Boolean
     jukeboxDepth: Int

--- a/src/main/resources/graphql/types.graphqls
+++ b/src/main/resources/graphql/types.graphqls
@@ -45,6 +45,7 @@ type UserProfile {
 
 type Preference {
     viewerControlEnabled: Boolean
+    viewerPageViewOnly: Boolean
     viewerControlMode: String
     resetVotes: Boolean
     jukeboxDepth: Int


### PR DESCRIPTION
Updated the Preference and PreferenceInput types in GraphQL to include the viewerPageViewOnly field. Also bumped the remote-falcon-library dependency to version 685018c867 in pom.xml.