### PR TITLE
Adds askWattson GraphQL query

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -83,6 +83,16 @@ spec:
             secretKeyRef:
               name: remote-falcon-control-panel
               key: s3-secretKey
+        - name: wattson.endpoint
+          valueFrom:
+            secretKeyRef:
+              name: remote-falcon-control-panel
+              key: wattson-endpoint
+        - name: wattson.key
+          valueFrom:
+            secretKeyRef:
+              name: remote-falcon-control-panel
+              key: wattson-key
         startupProbe:
           httpGet:
             path: /remote-falcon-control-panel/actuator/health

--- a/src/main/java/com/remotefalcon/controlpanel/controller/GraphQLController.java
+++ b/src/main/java/com/remotefalcon/controlpanel/controller/GraphQLController.java
@@ -2,6 +2,7 @@ package com.remotefalcon.controlpanel.controller;
 
 import com.remotefalcon.controlpanel.aop.RequiresAccess;
 import com.remotefalcon.controlpanel.aop.RequiresAdminAccess;
+import com.remotefalcon.controlpanel.model.AskWattson;
 import com.remotefalcon.controlpanel.response.ShowsOnAMap;
 import com.remotefalcon.library.documents.Notification;
 import com.remotefalcon.library.documents.Show;
@@ -242,5 +243,11 @@ public class GraphQLController {
     @RequiresAccess
     public List<ShowNotification> getNotifications() {
         return this.graphQLQueryService.getNotifications();
+    }
+
+    @QueryMapping
+    @RequiresAccess
+    public AskWattson askWattson(@Argument String prompt) {
+        return this.graphQLQueryService.askWattson(prompt);
     }
 }

--- a/src/main/java/com/remotefalcon/controlpanel/model/AskWattson.java
+++ b/src/main/java/com/remotefalcon/controlpanel/model/AskWattson.java
@@ -1,0 +1,49 @@
+package com.remotefalcon.controlpanel.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AskWattson {
+    private String id;
+    private String object;
+    private long created;
+    private String model;
+    private List<Choice> choices;
+    private Usage usage;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Choice {
+        private int index;
+        private Message message;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Message {
+        private String role;
+        private String content;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Usage {
+        private int promptTokens;
+        private int completionTokens;
+        private int totalTokens;
+    }
+}

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -8,4 +8,5 @@ type Query {
     getShowsAutoSuggest(showName: String!): [Show]
     getShowByShowSubdomain(showSubdomain: String!): Show
     getNotifications: [ShowNotification]
+    askWattson(prompt: String!): AskWattson
 }

--- a/src/main/resources/graphql/types.graphqls
+++ b/src/main/resources/graphql/types.graphqls
@@ -182,3 +182,28 @@ type ShowNotification {
     read: Boolean
     deleted: Boolean
 }
+
+type AskWattson {
+    id: ID
+    object: String
+    created: Long
+    model: String
+    choices: [AskWattsonChoice]
+    usage: AskWattsonUsage
+}
+
+type AskWattsonChoice {
+    index: Int
+    message: AskWattsonMessage
+}
+
+type AskWattsonMessage {
+    role: String
+    content: String
+}
+
+type AskWattsonUsage {
+    promptTokens: Int
+    completionTokens: Int
+    totalTokens: Int
+}


### PR DESCRIPTION
Implements a new GraphQL query to interact with the Wattson service.
This allows users to send prompts to Wattson and receive responses.

Fetches Wattson endpoint and API key from secrets.
