### PR TITLE
Integrates OpenAI for question answering

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -83,11 +83,6 @@ spec:
             secretKeyRef:
               name: remote-falcon-control-panel
               key: s3-secretKey
-        - name: wattson.endpoint
-          valueFrom:
-            secretKeyRef:
-              name: remote-falcon-control-panel
-              key: wattson-endpoint
         - name: wattson.key
           valueFrom:
             secretKeyRef:

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,11 @@
             <version>1.12.663</version>
         </dependency>
         <dependency>
+            <groupId>com.openai</groupId>
+            <artifactId>openai-java</artifactId>
+            <version>3.1.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.Remote-Falcon</groupId>
             <artifactId>remote-falcon-library</artifactId>
             <version>dcc2051989</version>

--- a/src/main/java/com/remotefalcon/controlpanel/controller/GraphQLController.java
+++ b/src/main/java/com/remotefalcon/controlpanel/controller/GraphQLController.java
@@ -247,7 +247,7 @@ public class GraphQLController {
 
     @QueryMapping
     @RequiresAccess
-    public AskWattson askWattson(@Argument String prompt) {
-        return this.graphQLQueryService.askWattson(prompt);
+    public AskWattson askWattson(@Argument String prompt, @Argument String previousResponseId) {
+        return this.graphQLQueryService.askWattson(prompt, previousResponseId);
     }
 }

--- a/src/main/java/com/remotefalcon/controlpanel/model/AskWattson.java
+++ b/src/main/java/com/remotefalcon/controlpanel/model/AskWattson.java
@@ -12,38 +12,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AskWattson {
-    private String id;
-    private String object;
-    private long created;
-    private String model;
-    private List<Choice> choices;
-    private Usage usage;
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class Choice {
-        private int index;
-        private Message message;
-    }
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class Message {
-        private String role;
-        private String content;
-    }
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class Usage {
-        private int prompt_tokens;
-        private int completion_tokens;
-        private int total_tokens;
-    }
+    private String responseId;
+    private String text;
 }

--- a/src/main/java/com/remotefalcon/controlpanel/util/WattsonUtil.java
+++ b/src/main/java/com/remotefalcon/controlpanel/util/WattsonUtil.java
@@ -1,0 +1,39 @@
+package com.remotefalcon.controlpanel.util;
+
+public class WattsonUtil {
+
+    public static final String WATTSON_INSTRUCTIONS = """
+            Answer user questions about xLights, FPP (Falcon Player), and Remote Falcon in a friendly, concise, and informative manner. Always consult the vector store files as the primary knowledge source before constructing your response, ensuring accuracy and relevancy. Avoid mentioning technical terms like "vector" or "vector store" in any response content. Remain clear and approachable, providing enough detail for the user to understand or solve their problem. Refer to tools, integrations, features, or procedures as presented in the knowledge base. Continue assisting until the question is thoroughly answered. Think step-by-step before providing your answer.
+            
+            ## Output Format
+            - Responses should be concise, clearly written in helpful, friendly language.
+            - Avoid technical jargon unless it is essential to the question.
+            - Only address the topic as it pertains to xLights, FPP, and Remote Falcon.
+            - Do not reference "vectors" or the underlying search method.
+            
+            ## Example Interactions
+            
+            **Example 1**
+            - User: How do I upload a sequence to FPP from xLights?
+            - Wattson: To upload a sequence from xLights to FPP, go to the "Tools" menu in xLights and select "Upload Output to FPP". Make sure FPP is running on your network and your controller is set up in xLights. Follow the prompts to upload your sequence files.
+            
+            **Example 2**
+            - User: What is Remote Falcon used for?
+            - Wattson: Remote Falcon lets your audience control your light show playlists and songs through a web interface. You can integrate it with FPP to create interactive light shows that viewers can participate in.
+            
+            **Example 3**
+            - User: My FPP player isn’t showing up in xLights, what should I check?
+            - Wattson: First, verify that your FPP device is powered on and connected to the same network as your xLights computer. Make sure the device's IP address in xLights matches the one assigned to your FPP player. Also, check for any firewall settings that might be blocking communication.
+            
+            (Real examples should be at least a few sentences, customized to the user's specific wording and context.)
+            
+            ## Important Considerations
+            - Never disclose or reference vector stores or retrieval mechanisms.
+            - If a direct answer cannot be found, suggest common troubleshooting or relevant documentation.
+            - Always use a friendly and concise tone.
+            
+            ---
+            
+            **Reminder:** Always check the vector store files for relevant answers first. Do NOT mention vector stores or related terms in your responses. Remain concise, accurate, and friendly. Continue assisting until all user questions are fully resolved.
+            """;
+}

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -8,5 +8,5 @@ type Query {
     getShowsAutoSuggest(showName: String!): [Show]
     getShowByShowSubdomain(showSubdomain: String!): Show
     getNotifications: [ShowNotification]
-    askWattson(prompt: String!): AskWattson
+    askWattson(prompt: String!, previousResponseId: String): AskWattson
 }

--- a/src/main/resources/graphql/types.graphqls
+++ b/src/main/resources/graphql/types.graphqls
@@ -185,26 +185,6 @@ type ShowNotification {
 }
 
 type AskWattson {
-    id: ID
-    object: String
-    created: Long
-    model: String
-    choices: [AskWattsonChoice]
-    usage: AskWattsonUsage
-}
-
-type AskWattsonChoice {
-    index: Int
-    message: AskWattsonMessage
-}
-
-type AskWattsonMessage {
-    role: String
-    content: String
-}
-
-type AskWattsonUsage {
-    prompt_tokens: Int
-    completion_tokens: Int
-    total_tokens: Int
+    responseId: String
+    text: String
 }


### PR DESCRIPTION
Replaces the existing Wattson integration with OpenAI's API to enhance question answering capabilities.

This allows for improved and more flexible responses to user queries by leveraging the power of OpenAI's models.
The previous Wattson implementation is removed and the AskWattson data model is updated to align with the new OpenAI API response format.
The `askWattson` GraphQL query is modified to accept a `previousResponseId` for contextual conversations.
