### PR TITLE
fix notifications

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -93,6 +93,11 @@ spec:
             secretKeyRef:
               name: remote-falcon-control-panel
               key: openai-model
+        - name: wattson.max_output_tokens
+          valueFrom:
+            secretKeyRef:
+              name: remote-falcon-control-panel
+              key: max-output-tokens
         startupProbe:
           httpGet:
             path: /remote-falcon-control-panel/actuator/health

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
@@ -487,7 +487,9 @@ public class GraphQLMutationService {
         Optional<Show> show = this.showRepository.findByShowToken(authUtil.tokenDTO.getShowToken());
         if(show.isPresent()) {
             Show existingShow = show.get();
-            existingShow.getShowNotifications().forEach(showNotification -> {
+            Optional.ofNullable(existingShow.getShowNotifications())
+                    .orElse(Collections.emptyList())
+                    .forEach(showNotification -> {
                 if(uuids.contains(showNotification.getNotification().getUuid())) {
                     showNotification.setRead(true);
                 }
@@ -502,7 +504,9 @@ public class GraphQLMutationService {
         Optional<Show> show = this.showRepository.findByShowToken(authUtil.tokenDTO.getShowToken());
         if(show.isPresent()) {
             Show existingShow = show.get();
-            existingShow.getShowNotifications().forEach(showNotification -> {
+            Optional.ofNullable(existingShow.getShowNotifications())
+                    .orElse(Collections.emptyList())
+                    .forEach(showNotification -> {
                 if (Objects.equals(showNotification.getNotification().getUuid(), uuid)) {
                     showNotification.setDeleted(true);
                 }
@@ -541,10 +545,9 @@ public class GraphQLMutationService {
                 .deleted(false)
                 .build();
         if(show.getShowNotifications() == null) {
-            show.setShowNotifications(List.of(showNotification));
-        }else {
-            show.getShowNotifications().add(showNotification);
+            show.setShowNotifications(new ArrayList<>());
         }
+        show.getShowNotifications().add(showNotification);
     }
 
     public Boolean deleteNotification(String uuid) {
@@ -552,3 +555,4 @@ public class GraphQLMutationService {
         return true;
     }
 }
+

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLQueryService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLQueryService.java
@@ -221,8 +221,6 @@ public class GraphQLQueryService {
 
             // Keep, but update the master Notification details
             userSN.setNotification(repoNotif);
-            // If marked read by user, keep it; otherwise leave as-is (default false)
-            userSN.setRead(Boolean.TRUE.equals(userSN.getRead()));
             merged.add(userSN);
         }
 
@@ -373,3 +371,4 @@ public class GraphQLQueryService {
         }
     }
 }
+

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLQueryService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLQueryService.java
@@ -182,12 +182,18 @@ public class GraphQLQueryService {
 
         // Index user's notifications by UUID (null-safe)
         Map<String, ShowNotification> userByUuid = new HashMap<>();
+        Map<String, ShowNotification> userById = new HashMap<>();
         for (ShowNotification sn : userNotifs) {
             if (sn == null) continue;
             Notification n = sn.getNotification();
-            String uuid = (n == null) ? null : n.getUuid();
+            if (n == null) continue;
+            String uuid = n.getUuid();
+            String id = n.getId();
             if (uuid != null) {
                 userByUuid.put(uuid, sn);
+            }
+            if (id != null) {
+                userById.put(id, sn);
             }
         }
 
@@ -195,7 +201,11 @@ public class GraphQLQueryService {
 
         for (Notification repoNotif : repoNotifications) {
             if (repoNotif == null || repoNotif.getUuid() == null) continue;
+            // First try to match by UUID; if that fails, fall back to Mongo ID.
             ShowNotification userSN = userByUuid.remove(repoNotif.getUuid());
+            if (userSN == null && repoNotif.getId() != null) {
+                userSN = userById.remove(repoNotif.getId());
+            }
 
             if (userSN == null) {
                 // New to user → add default state

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,3 +8,5 @@ client:
   header: "CF-Connecting-IP"
 
 auto-validate-email: true
+
+wattson.max_output_tokens: 4096


### PR DESCRIPTION
- **feat: SSE streaming improvements (OpenAI Responses streaming, markdown-friendly chunking, meta format hint); add vector-store router; make max output tokens configurable; trim instructions; compact user settings; fix and harden getNotifications merge logic (preserve ADMIN deletions, drop stale FPP_HEALTH, carry user-only, remove ADMIN when missing in repo); add reasoning deltas handling and fallbacks**
- **GraphQL: null-safe notification handling and mutable list init\n\n- Safely iterate notifications in markNotificationsAsRead/deleteNotificationForUser\n- Initialize showNotifications with ArrayList to avoid immutability**
- **Notifications: preserve read flag during merge in getNotifications\n\n- Do not overwrite existing read state for ADMIN/user notifications\n- Avoid accidental reset to false on fetch**
- **fix(notifications): preserve read state for ADMIN by falling back to Notification id when uuid mismatch during merge**
