### PR TITLE
feat: make images bucket and CDN endpoint env-configurable

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -83,6 +83,10 @@ spec:
             secretKeyRef:
               name: remote-falcon-control-panel
               key: s3-secretKey
+        - name: IMAGES_S3_BUCKET
+          value: remote-falcon-uploads
+        - name: IMAGES_CDN_ENDPOINT
+          value: https://remote-falcon-uploads.nyc3.digitaloceanspaces.com
         - name: WATTSON_KEY
           valueFrom:
             secretKeyRef:

--- a/src/main/java/com/remotefalcon/controlpanel/util/S3Util.java
+++ b/src/main/java/com/remotefalcon/controlpanel/util/S3Util.java
@@ -3,6 +3,7 @@ package com.remotefalcon.controlpanel.util;
 import com.remotefalcon.controlpanel.model.S3Image;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,8 +33,11 @@ import java.util.Objects;
 public class S3Util {
   private final S3Client amazonS3Client;
 
-  private final String bucketName = "remote-falcon-images";
-  private final String cdnEndpoint = String.format("https://%s.nyc3.cdn.digitaloceanspaces.com", bucketName);
+  @Value("${images.s3.bucket}")
+  private String bucketName;
+
+  @Value("${images.cdn.endpoint}")
+  private String cdnEndpoint;
 
   public ResponseEntity<String> uploadFile(MultipartFile file, String showSubdomain) {
     String path = String.format("%s/%s", showSubdomain,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,12 @@ management:
 sendgrid:
   mail-from: "noreply@remotefalcon.com"
 
+images:
+  s3:
+    bucket: ${IMAGES_S3_BUCKET:remote-falcon-images}
+  cdn:
+    endpoint: ${IMAGES_CDN_ENDPOINT:https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com}
+
 logging:
   level:
     org:


### PR DESCRIPTION
## Summary
- Replace hardcoded `remote-falcon-images` bucket name and CDN endpoint in `S3Util` with env-driven config (`IMAGES_S3_BUCKET`, `IMAGES_CDN_ENDPOINT`).
- Defaults match the previous hardcoded values, so existing deployments are unaffected.
- `k8s/manifest.yml` pins `IMAGES_S3_BUCKET=remote-falcon-uploads` and `IMAGES_CDN_ENDPOINT=https://remote-falcon-uploads.nyc3.digitaloceanspaces.com` for this deployment.

## Test plan
- [ ] Boot with no env override: bucket name resolves to `remote-falcon-images` (default preserved).
- [ ] After merge + deploy: `kubectl describe pod -l app=remote-falcon-control-panel` shows `IMAGES_S3_BUCKET=remote-falcon-uploads`.
- [ ] Image upload from the control-panel UI succeeds (no S3 403; ListObjectsV2 + PutObject hit the new bucket).
- [ ] Uploaded images render in the UI (CDN endpoint URL serves the image).