### PR TITLE
chore: move MailerSend template IDs to env vars

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -58,6 +58,12 @@ spec:
             secretKeyRef:
               name: remote-falcon-control-panel
               key: sendgrid-key
+        - name: MAILERSEND_TEMPLATE_SIGN_UP
+          value: "v69oxl59ndrg785k"
+        - name: MAILERSEND_TEMPLATE_FORGOT_PASSWORD
+          value: "ynrw7gy02w2l2k8e"
+        - name: MAILERSEND_TEMPLATE_REQUEST_API_ACCESS
+          value: "yzkq340rd104d796"
         - name: JWT_USER
           valueFrom:
             secretKeyRef:

--- a/src/main/java/com/remotefalcon/controlpanel/util/EmailUtil.java
+++ b/src/main/java/com/remotefalcon/controlpanel/util/EmailUtil.java
@@ -20,11 +20,20 @@ public class EmailUtil {
   @Value("${web.url}")
   String webUrl;
 
+  @Value("${mailersend.template-ids.sign-up}")
+  String signUpTemplateId;
+
+  @Value("${mailersend.template-ids.forgot-password}")
+  String forgotPasswordTemplateId;
+
+  @Value("${mailersend.template-ids.request-api-access}")
+  String requestApiAccessTemplateId;
+
   public MailerSendResponse sendSignUpEmail(Show show) {
     Email email = new Email();
     email.addRecipient(show.getShowName(), show.getEmail());
 
-    email.setTemplateId("3z0vklojo3eg7qrx");
+    email.setTemplateId(signUpTemplateId);
     email.setSubject("Welcome to Remote Falcon!");
     email.AddVariable("showName", show.getShowName());
     email.AddVariable("verifyEmailLink", String.format("%s/verifyEmail/%s/%s", webUrl, show.getShowToken(), show.getShowSubdomain()));
@@ -34,7 +43,7 @@ public class EmailUtil {
   public MailerSendResponse sendForgotPasswordEmail(Show show, String passwordResetLink) {
     Email email = new Email();
     email.addRecipient(show.getShowName(), show.getEmail());
-    email.setTemplateId("3vz9dlejwxp4kj50");
+    email.setTemplateId(forgotPasswordTemplateId);
     email.setSubject("You forgot your password, huh?");
     email.AddVariable("resetPasswordLink", String.format("%s/resetPassword/%s", webUrl, passwordResetLink));
     return sendEmail(email);
@@ -43,7 +52,7 @@ public class EmailUtil {
   public MailerSendResponse sendRequestApiAccessEmail(Show show, String apiAccessToken, String apiAccessSecret) {
     Email email = new Email();
     email.addRecipient(show.getShowName(), show.getEmail());
-    email.setTemplateId("3yxj6lj6e304do2r");
+    email.setTemplateId(requestApiAccessTemplateId);
     email.setSubject("Let's Get Coding!");
     email.AddVariable("accessToken", apiAccessToken);
     email.AddVariable("secretKey", apiAccessSecret);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,12 @@ management:
 sendgrid:
   mail-from: "noreply@remotefalcon.com"
 
+mailersend:
+  template-ids:
+    sign-up: ${MAILERSEND_TEMPLATE_SIGN_UP:v69oxl59ndrg785k}
+    forgot-password: ${MAILERSEND_TEMPLATE_FORGOT_PASSWORD:ynrw7gy02w2l2k8e}
+    request-api-access: ${MAILERSEND_TEMPLATE_REQUEST_API_ACCESS:yzkq340rd104d796}
+
 images:
   s3:
     bucket: ${IMAGES_S3_BUCKET:remote-falcon-images}


### PR DESCRIPTION
## Summary
- Replaces three hardcoded MailerSend template IDs in `EmailUtil` with `@Value` injection backed by `mailersend.template-ids.*` properties.
- Adds defaults in `application.yml` matching the new MailerSend account, so local dev / tests work without extra setup.
- Wires explicit env vars in `k8s/manifest.yml` so prod config is visible at the deploy layer and future template rotations don't require a code change.

## Test plan
- [ ] Build passes locally (`mvn package`)
- [ ] Existing tests pass (`mvn test`)
- [ ] Sign-up email sends using new template ID after deploy
- [ ] Forgot-password email sends using new template ID after deploy
- [ ] API access email sends using new template ID after deploy