### PR TITLE
chore: point IMAGES_CDN_ENDPOINT at the Spaces CDN host

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -92,7 +92,7 @@ spec:
         - name: IMAGES_S3_BUCKET
           value: remote-falcon-uploads
         - name: IMAGES_CDN_ENDPOINT
-          value: https://remote-falcon-uploads.nyc3.digitaloceanspaces.com
+          value: https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com
         - name: WATTSON_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary
- Switch `IMAGES_CDN_ENDPOINT` from the direct origin host to the DO Spaces CDN host so newly uploaded show images are served via the CDN edge.
- Old: `https://remote-falcon-uploads.nyc3.digitaloceanspaces.com`
- New: `https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com`

The Spaces CDN was just enabled on the `remote-falcon-uploads` bucket. Existing `show.sequences[].imageUrl` values in Mongo are unaffected — only newly uploaded images going forward will be written with the CDN host. A separate follow-up will rewrite the legacy URLs that still point at the old `remote-falcon-images` bucket.

## Test plan
- [ ] Deploy `remote-falcon-control-panel` and upload a new show image
- [ ] Confirm the persisted `imageUrl` uses `…nyc3.cdn.digitaloceanspaces.com`
- [ ] Confirm the image renders on the viewer page (CDN cache hit)