### PR TITLE
feat: codify replicas=2 + HPA to match live cluster state

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -63,7 +63,7 @@ jobs:
           Application: remote-falcon-control-panel
           Version: ${{ github.sha }}
           Env: prod
-          Replicas: 1
+          Replicas: 2
           Image: ${{ env.REGISTRY }}/${{ steps.repository_string.outputs.lowercase }}:${{ github.sha }}
           Requests.Memory: 256Mi
           Requests.CPU: 100m

--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -165,3 +165,23 @@ spec:
             name: #{Application}#
             port:
               number: 8080
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: #{Application}#
+  namespace: #{Namespace}#
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: #{Application}#
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70


### PR DESCRIPTION
The control-panel deployment is currently running with `replicas: 2` and an HPA (`min=2`, `max=4`, `cpu=70%`) that were applied imperatively via `kubectl` during the recent cutover. The repo's manifest and release workflow still substituted `Replicas: 1` with no HPA defined, so the next push to `main` would have reverted both changes during `kubectl apply`. This PR commits the live cluster state into source control: bumps the workflow's `Replicas` token to `2` and appends a `HorizontalPodAutoscaler` resource to `k8s/manifest.yml`. No runtime behavior changes — this just stops future deploys from undoing the scaling that's already in place.