### PR TITLE
feat(bootstrap): ensure Show collection indexes on startup

### DIFF
--- a/src/main/java/com/remotefalcon/controlpanel/configuration/MongoIndexInitializer.java
+++ b/src/main/java/com/remotefalcon/controlpanel/configuration/MongoIndexInitializer.java
@@ -1,0 +1,66 @@
+package com.remotefalcon.controlpanel.configuration;
+
+import com.remotefalcon.library.documents.Show;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.query.Collation;
+import org.springframework.stereotype.Component;
+
+/**
+ * Ensures the production indexes on the {@code show} collection exist at startup.
+ *
+ * <p>Historically these indexes were applied imperatively via {@code mongosh} against
+ * the live cluster, which left fresh environments (local dev, new clusters, ephemeral
+ * test envs) silently unindexed until someone remembered to run the script. Wiring
+ * them into {@link ApplicationReadyEvent} makes the bootstrap automatic and idempotent:
+ * {@link org.springframework.data.mongodb.core.index.IndexOperations#ensureIndex}
+ * creates the index if missing, no-ops if an identical spec already exists, and throws
+ * if the existing spec differs (which is the desired safety net for accidental drift).
+ *
+ * <p>Indexes ensured:
+ * <ul>
+ *   <li>{@code idx_showToken} — unique index on {@code showToken}</li>
+ *   <li>{@code idx_email_ci} — unique index on {@code email} with case-insensitive
+ *       collation ({@code locale: "en", strength: 2})</li>
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MongoIndexInitializer {
+
+  private final MongoTemplate mongoTemplate;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void ensureShowIndexes() {
+    long start = System.currentTimeMillis();
+    try {
+      mongoTemplate.indexOps(Show.class).ensureIndex(
+          new Index()
+              .on("showToken", Sort.Direction.ASC)
+              .named("idx_showToken")
+              .unique()
+      );
+      mongoTemplate.indexOps(Show.class).ensureIndex(
+          new Index()
+              .on("email", Sort.Direction.ASC)
+              .named("idx_email_ci")
+              .unique()
+              .collation(Collation.of("en").strength(Collation.ComparisonLevel.secondary()))
+      );
+      log.info("Show collection indexes ensured in {} ms",
+               System.currentTimeMillis() - start);
+    } catch (Exception e) {
+      // Don't crash startup on a transient Mongo issue or a benign index spec
+      // conflict — log loudly and let the pod come up. The deploy-fix is then to
+      // investigate the conflict (probably a spec mismatch against an existing
+      // index of the same name).
+      log.error("Failed to ensure Show indexes: {}", e.getMessage(), e);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The two production indexes on the \`show\` collection are required for correct behavior:

- \`idx_showToken\` (unique on \`showToken\`) — backs every authenticated lookup. Without it: COLLSCAN on every GraphQL call.
- \`idx_email_ci\` (unique on \`email\` with collation \`{ locale: "en", strength: 2 }\`) — backs the \`findByEmailCollation\` repository method introduced in #73 (login path). Without an index whose collation matches the query's, MongoDB refuses to use it — login becomes a full-collection scan.

Today these indexes are applied imperatively via \`mongosh\` against the live cluster. Fresh environments (local dev via \`dev-up.sh\`, the soon-to-be-built new DO cluster, ephemeral test envs) come up silently unindexed until somebody remembers to re-run the script. There is no automation and no safety net.

## Fix

Adds a \`MongoIndexInitializer\` \`@Component\` that hooks \`ApplicationReadyEvent\` and calls \`MongoTemplate#indexOps(Show.class).ensureIndex(...)\` for both indexes. \`ensureIndex\` is idempotent:

- Index missing → creates it with the spec.
- Index present and spec matches → no-op.
- Index present but spec differs → throws (the safety net we want — flag accidental drift so an operator investigates).

The two index definitions match the live cluster exactly. The first deploy is a pure verification run — no recreation, no downtime, no migration risk.

## Why the try/catch

We deliberately swallow exceptions and log at \`error\` level rather than crash-loop the pod. A transient Mongo blip during startup shouldn't take the control-panel offline; if a spec conflict ever does surface, crash-looping makes triage harder. Letting the pod come up means the operator gets a loud \`error\` line and can investigate with the service still serving traffic.

## Test plan

- [x] \`mvn compile\` — clean build (verified by agent in maven:3.9-eclipse-temurin-21 container)
- [ ] Local: bring up via \`dev-up.sh up mongo control-panel\` on a fresh \`mongo-data\` volume; tail logs for \`Show collection indexes ensured in <N> ms\` and verify via \`db.show.getIndexes()\`.
- [ ] Re-start the same pod; confirm second invocation is a no-op (no creation logged at the Mongo level).
- [ ] Manually create a conflicting \`idx_email_ci\` (different collation strength) on a throwaway env; restart; confirm \`error\` log line and pod still becomes Ready.
- [ ] Deploy to prod via \`build-and-release.yml\`. The two prod indexes already match the spec, so the first run logs success and changes nothing.