### PR TITLE
feat(retention): scheduled 18-month stats sweep at 3am UTC

### DIFF
--- a/src/main/java/com/remotefalcon/controlpanel/scheduler/ScheduledTaskController.java
+++ b/src/main/java/com/remotefalcon/controlpanel/scheduler/ScheduledTaskController.java
@@ -14,4 +14,15 @@ public class ScheduledTaskController {
     public void runTask() {
         // scheduledTaskService.fppHeartbeatTask();
     }
+
+    /**
+     * Nightly 18-month stats retention sweep at 03:00 UTC.
+     * Iterates every show via a streaming cursor and trims stats older than 18
+     * months. Replaces the dashboard-mount trigger removed in UI PR #67
+     * (PERF-FIX-PLAN Phase 1).
+     */
+    @Scheduled(cron = "0 0 3 * * ?")
+    public void purgeStaleStats() {
+        scheduledTaskService.purgeStaleStatsForAllShows();
+    }
 }

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
@@ -437,17 +437,33 @@ public class GraphQLMutationService {
     public Boolean purgeStats() {
         Optional<Show> show = this.showRepository.findByShowToken(authUtil.getTokenDTO().getShowToken());
         if(show.isPresent()) {
-            LocalDateTime purgeStatsDate = LocalDateTime.now().minusMonths(18);
-
-            show.get().getStats().getPage().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-            show.get().getStats().getJukebox().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-            show.get().getStats().getVoting().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-            show.get().getStats().getVotingWin().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-
-            this.showRepository.save(show.get());
+            this.purgeStatsForShow(show.get());
             return true;
         }
         throw new RuntimeException(StatusResponse.UNEXPECTED_ERROR.name());
+    }
+
+    public void purgeStatsForShow(Show show) {
+        if(show.getStats() == null) {
+            return;
+        }
+        LocalDateTime purgeStatsDate = LocalDateTime.now().minusMonths(18);
+        boolean changed = false;
+        if(show.getStats().getPage() != null) {
+            changed |= show.getStats().getPage().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(show.getStats().getJukebox() != null) {
+            changed |= show.getStats().getJukebox().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(show.getStats().getVoting() != null) {
+            changed |= show.getStats().getVoting().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(show.getStats().getVotingWin() != null) {
+            changed |= show.getStats().getVotingWin().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(changed) {
+            this.showRepository.save(show);
+        }
     }
 
     public Boolean deleteStatsWithinRange(Long startDate, Long endDate, String timezone) {

--- a/src/main/java/com/remotefalcon/controlpanel/service/ScheduledTaskService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/ScheduledTaskService.java
@@ -2,7 +2,9 @@ package com.remotefalcon.controlpanel.service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.remotefalcon.controlpanel.repository.ShowRepository;
 import com.remotefalcon.library.documents.Notification;
@@ -10,6 +12,8 @@ import com.remotefalcon.library.documents.Show;
 import com.remotefalcon.library.enums.NotificationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,6 +23,7 @@ public class ScheduledTaskService {
     private final ShowRepository showRepository;
     private final ExpoNotificationService expoNotificationService;
     private final GraphQLMutationService graphQLMutationService;
+    private final MongoTemplate mongoTemplate;
 
     public void fppHeartbeatTask() {
         List<Show> showsToNotify = showRepository.findByPreferencesNotificationPreferencesEnableFppHeartbeatIsTrueAndLastFppHeartbeatBefore(LocalDateTime.now().minusMinutes(5));
@@ -49,5 +54,34 @@ public class ScheduledTaskService {
                 log.info("Sent FPP heartbeat notification to {}", show.getShowName());
             }
         });
+    }
+
+    /**
+     * Iterates every show via a streaming Mongo cursor and applies the 18-month
+     * stats retention policy one document at a time. Uses {@link MongoTemplate#stream}
+     * (not {@code findAll}) to avoid materializing the full collection in memory:
+     * populated show documents average ~130 KB, so 1000+ shows would otherwise
+     * exceed the control-panel pod's 512 Mi memory limit.
+     */
+    public void purgeStaleStatsForAllShows() {
+        int swept = 0;
+        int errored = 0;
+        long startMillis = System.currentTimeMillis();
+        try (Stream<Show> shows = mongoTemplate.stream(new Query(), Show.class)) {
+            Iterator<Show> it = shows.iterator();
+            while (it.hasNext()) {
+                Show show = it.next();
+                try {
+                    graphQLMutationService.purgeStatsForShow(show);
+                    swept++;
+                } catch (Exception e) {
+                    log.warn("Stats retention sweep failed for show {}: {}",
+                            show.getShowToken(), e.getMessage());
+                    errored++;
+                }
+            }
+        }
+        log.info("Stats retention sweep complete: {} shows processed, {} errored, {} ms",
+                swept, errored, System.currentTimeMillis() - startMillis);
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 of PERF-FIX-PLAN. Restores 18-month stats retention enforcement on a backend cron after Phase 1 (UI PR #67) removed the dashboard-mount trigger that previously fired \`purgeStats\` on every page load. The published privacy policy promises "we don't store data longer than 18 months." Phase 1 paused enforcement to fix the dashboard-mount performance regression; this PR resumes it where it belongs — in the backend, on a schedule, sweeping every show.

## What changed

1. **Refactor \`GraphQLMutationService.purgeStats\`.** Extracts the actual trimming into a new \`purgeStatsForShow(Show)\` method shared by the existing admin/manual mutation and the new sweep. The mutation is preserved for admin use.
2. **New \`ScheduledTaskService.purgeStaleStatsForAllShows\`.** Iterates every show one at a time and delegates to \`purgeStatsForShow\`. Per-show errors are logged and counted but do not abort the sweep.
3. **New \`@Scheduled(cron = "0 0 3 * * ?")\` in \`ScheduledTaskController\`.** Fires daily at 03:00 UTC, sibling to the existing (commented-out) \`runTask\`. \`@EnableScheduling\` is already on \`Application.java\`.

## Bounded-memory streaming

Populated \`show\` documents average ~130 KB. With 1000+ shows, \`showRepository.findAll()\` would pull ~130 MB into heap at once, exceeding the control-panel pod's 512 Mi limit and OOM-killing the pod. The sweep uses \`mongoTemplate.stream(new Query(), Show.class)\` inside a try-with-resources, iterating one document at a time so peak heap stays roughly one show's worth.

## If-changed-save optimization

\`purgeStatsForShow\` tracks whether any list actually had entries removed and only calls \`showRepository.save\` when something changed. Most nights, most shows have nothing 18+ months old, so this avoids 1000+ unnecessary Mongo writes per sweep.

## Sweep duration

Bottlenecked by the Mongo public-routing bug today (~250 ms per round-trip). Estimated wall time ~8 minutes for 1000 shows. Once Mongo private routing is restored, end-to-end should drop below ~30 seconds. The cron runs at 03:00 UTC, well outside peak load.

## Admin mutation preserved

The GraphQL \`purgeStats\` mutation still exists for admin/manual triggers; it now calls the same shared \`purgeStatsForShow\` helper.

## Test plan

- [ ] \`@EnableScheduling\` confirmed present at \`Application.java:18\`.
- [ ] Local: bring up via \`./dev-up.sh\`, temporarily change cron to a near-future minute, verify the log line \`Stats retention sweep complete: ... shows processed\` appears, then revert cron.
- [ ] Manually invoke the existing \`purgeStats\` GraphQL mutation as a logged-in user; confirm it still works (regression check on the refactor).
- [ ] On a test show with stats older than 18 months, confirm old entries are removed after the sweep.
- [ ] \`kubectl top pod -n remote-falcon\` during a sweep — confirm memory stays within \`512 Mi\`.