### PR TITLE
feat(config): tighten Mongo health probe to 3s and update bucket defaults

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,9 @@ management:
         allowed-origins: "*"
         allowed-methods: "OPTIONS, GET, POST, PUT, DELETE"
         allowed-headers: "*"
+  health:
+    mongo:
+      timeout: 3s
 
 sendgrid:
   mail-from: "noreply@remotefalcon.com"
@@ -41,9 +44,9 @@ mailersend:
 
 images:
   s3:
-    bucket: ${IMAGES_S3_BUCKET:remote-falcon-images}
+    bucket: ${IMAGES_S3_BUCKET:remote-falcon-uploads}
   cdn:
-    endpoint: ${IMAGES_CDN_ENDPOINT:https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com}
+    endpoint: ${IMAGES_CDN_ENDPOINT:https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com}
 
 logging:
   level:


### PR DESCRIPTION
Two small, focused config-hardening changes to \`application.yml\`. Bundled because both are single-line YAML hardening with no functional overlap; reviewing as one PR is cheaper than two.

## 1. Mongo health probe timeout: default → 3s

Spring Boot's default \`MongoHealthIndicator\` timeout is too long. When Mongo blips, every replica goes unready in lockstep and the whole service can drop. Tightening to 3 seconds via the standard \`management.health.mongo.timeout\` Actuator property lets a slow replica fail its probe and get rotated out before it takes the rest of the pool down with it.

## 2. Bucket fallback defaults: \`remote-falcon-images\` → \`remote-falcon-uploads\`

Prod is unaffected because the k8s manifest overrides \`IMAGES_S3_BUCKET\` and \`IMAGES_CDN_ENDPOINT\` via env. But:

- Local dev without env vars writes to the old bucket.
- Any new k8s env that omits the env block falls back to it.
- Once the old bucket is deleted, the defaults become a 500-on-upload time-bomb.

Updating the fallbacks closes that gap. No behavior change for existing prod deploys.

## Test plan
- [ ] Confirm \`./dev-up.sh up control-panel\` starts cleanly with the new YAML.
- [ ] On next prod deploy, confirm \`/actuator/health\` returns 200 (Mongo health probe still works at 3s).
- [ ] Verify image upload still lands in \`remote-falcon-uploads\` (the env override still wins).