### PR TITLE
feat(signup): case-insensitive email uniqueness check

### DIFF
--- a/src/main/java/com/remotefalcon/controlpanel/repository/ShowRepository.java
+++ b/src/main/java/com/remotefalcon/controlpanel/repository/ShowRepository.java
@@ -17,7 +17,6 @@ public interface ShowRepository extends MongoRepository<Show, String> {
     Optional<Show> findByShowToken(String showToken);
     Optional<Show> findByShowSubdomain(String showSubdomain);
     Optional<Show> findByShowName(String showName);
-    Optional<Show> findByEmailOrShowSubdomain(String email, String showSubdomain);
 
     // Case-insensitive email lookup that uses the idx_email_ci index (collation strength=2).
     // Spring Data's derived findByEmailIgnoreCase uses $regex /i which can't use the index.

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
@@ -52,8 +52,8 @@ public class GraphQLMutationService {
         if (basicAuthCredentials != null) {
             String email = basicAuthCredentials[0];
             String password = basicAuthCredentials[1];
-            Optional<Show> show = this.showRepository.findByEmailOrShowSubdomain(email, showSubdomain);
-            if (show.isPresent()) {
+            if (this.showRepository.findByEmailCollation(email).isPresent()
+                    || this.showRepository.findByShowSubdomain(showSubdomain).isPresent()) {
                 throw new RuntimeException(StatusResponse.SHOW_EXISTS.name());
             }
             String showToken = this.validateShowToken(RandomUtil.generateToken(25));


### PR DESCRIPTION
Sign-up's duplicate-email pre-check was case-sensitive while the live \`idx_email_ci\` Mongo unique index (collation \`{ locale: 'en', strength: 2 }\`) is case-insensitive. The mismatch meant a user signing up with an email that differs only in case from an existing account passed the application-layer check, then failed at the DB write with a \`DuplicateKeyException\` that surfaced to the user as a generic 500.

This change splits the pre-check into a case-insensitive email lookup (\`findByEmailCollation\`, which uses \`idx_email_ci\`) and a case-sensitive subdomain lookup (\`findByShowSubdomain\`), so sign-up now consistently returns \`SHOW_EXISTS\` for duplicate emails regardless of casing.

Cost is one extra Mongo round-trip on the signup path (both queries are indexed; ~5ms worst case) — fine trade for the UX win on a low-traffic endpoint. The newly-orphaned \`findByEmailOrShowSubdomain\` repository method is also removed.

## Test plan
- [ ] Sign up with email \`Foo@example.com\`, then attempt second signup with \`foo@example.com\` → expect clean \`SHOW_EXISTS\` error (not 500).
- [ ] Sign up with a fresh email and an already-taken subdomain → expect \`SHOW_EXISTS\` error.
- [ ] Sign up with both fresh email and fresh subdomain → expect success.
- [ ] Confirm \`grep -rn "findByEmailOrShowSubdomain" src/\` returns nothing post-merge.