### PR TITLE
feat: control-panel post-cutover hardening (bootstrap + retention + config + signup)

### DIFF
--- a/src/main/java/com/remotefalcon/controlpanel/configuration/MongoIndexInitializer.java
+++ b/src/main/java/com/remotefalcon/controlpanel/configuration/MongoIndexInitializer.java
@@ -1,0 +1,66 @@
+package com.remotefalcon.controlpanel.configuration;
+
+import com.remotefalcon.library.documents.Show;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.query.Collation;
+import org.springframework.stereotype.Component;
+
+/**
+ * Ensures the production indexes on the {@code show} collection exist at startup.
+ *
+ * <p>Historically these indexes were applied imperatively via {@code mongosh} against
+ * the live cluster, which left fresh environments (local dev, new clusters, ephemeral
+ * test envs) silently unindexed until someone remembered to run the script. Wiring
+ * them into {@link ApplicationReadyEvent} makes the bootstrap automatic and idempotent:
+ * {@link org.springframework.data.mongodb.core.index.IndexOperations#ensureIndex}
+ * creates the index if missing, no-ops if an identical spec already exists, and throws
+ * if the existing spec differs (which is the desired safety net for accidental drift).
+ *
+ * <p>Indexes ensured:
+ * <ul>
+ *   <li>{@code idx_showToken} — unique index on {@code showToken}</li>
+ *   <li>{@code idx_email_ci} — unique index on {@code email} with case-insensitive
+ *       collation ({@code locale: "en", strength: 2})</li>
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MongoIndexInitializer {
+
+  private final MongoTemplate mongoTemplate;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void ensureShowIndexes() {
+    long start = System.currentTimeMillis();
+    try {
+      mongoTemplate.indexOps(Show.class).ensureIndex(
+          new Index()
+              .on("showToken", Sort.Direction.ASC)
+              .named("idx_showToken")
+              .unique()
+      );
+      mongoTemplate.indexOps(Show.class).ensureIndex(
+          new Index()
+              .on("email", Sort.Direction.ASC)
+              .named("idx_email_ci")
+              .unique()
+              .collation(Collation.of("en").strength(Collation.ComparisonLevel.secondary()))
+      );
+      log.info("Show collection indexes ensured in {} ms",
+               System.currentTimeMillis() - start);
+    } catch (Exception e) {
+      // Don't crash startup on a transient Mongo issue or a benign index spec
+      // conflict — log loudly and let the pod come up. The deploy-fix is then to
+      // investigate the conflict (probably a spec mismatch against an existing
+      // index of the same name).
+      log.error("Failed to ensure Show indexes: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/com/remotefalcon/controlpanel/repository/ShowRepository.java
+++ b/src/main/java/com/remotefalcon/controlpanel/repository/ShowRepository.java
@@ -17,7 +17,6 @@ public interface ShowRepository extends MongoRepository<Show, String> {
     Optional<Show> findByShowToken(String showToken);
     Optional<Show> findByShowSubdomain(String showSubdomain);
     Optional<Show> findByShowName(String showName);
-    Optional<Show> findByEmailOrShowSubdomain(String email, String showSubdomain);
 
     // Case-insensitive email lookup that uses the idx_email_ci index (collation strength=2).
     // Spring Data's derived findByEmailIgnoreCase uses $regex /i which can't use the index.

--- a/src/main/java/com/remotefalcon/controlpanel/scheduler/ScheduledTaskController.java
+++ b/src/main/java/com/remotefalcon/controlpanel/scheduler/ScheduledTaskController.java
@@ -14,4 +14,15 @@ public class ScheduledTaskController {
     public void runTask() {
         // scheduledTaskService.fppHeartbeatTask();
     }
+
+    /**
+     * Nightly 18-month stats retention sweep at 03:00 UTC.
+     * Iterates every show via a streaming cursor and trims stats older than 18
+     * months. Replaces the dashboard-mount trigger removed in UI PR #67
+     * (PERF-FIX-PLAN Phase 1).
+     */
+    @Scheduled(cron = "0 0 3 * * ?")
+    public void purgeStaleStats() {
+        scheduledTaskService.purgeStaleStatsForAllShows();
+    }
 }

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
@@ -437,17 +437,33 @@ public class GraphQLMutationService {
     public Boolean purgeStats() {
         Optional<Show> show = this.showRepository.findByShowToken(authUtil.getTokenDTO().getShowToken());
         if(show.isPresent()) {
-            LocalDateTime purgeStatsDate = LocalDateTime.now().minusMonths(18);
-
-            show.get().getStats().getPage().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-            show.get().getStats().getJukebox().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-            show.get().getStats().getVoting().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-            show.get().getStats().getVotingWin().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
-
-            this.showRepository.save(show.get());
+            this.purgeStatsForShow(show.get());
             return true;
         }
         throw new RuntimeException(StatusResponse.UNEXPECTED_ERROR.name());
+    }
+
+    public void purgeStatsForShow(Show show) {
+        if(show.getStats() == null) {
+            return;
+        }
+        LocalDateTime purgeStatsDate = LocalDateTime.now().minusMonths(18);
+        boolean changed = false;
+        if(show.getStats().getPage() != null) {
+            changed |= show.getStats().getPage().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(show.getStats().getJukebox() != null) {
+            changed |= show.getStats().getJukebox().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(show.getStats().getVoting() != null) {
+            changed |= show.getStats().getVoting().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(show.getStats().getVotingWin() != null) {
+            changed |= show.getStats().getVotingWin().removeIf(stat -> stat.getDateTime().isBefore(purgeStatsDate));
+        }
+        if(changed) {
+            this.showRepository.save(show);
+        }
     }
 
     public Boolean deleteStatsWithinRange(Long startDate, Long endDate, String timezone) {

--- a/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/GraphQLMutationService.java
@@ -52,8 +52,8 @@ public class GraphQLMutationService {
         if (basicAuthCredentials != null) {
             String email = basicAuthCredentials[0];
             String password = basicAuthCredentials[1];
-            Optional<Show> show = this.showRepository.findByEmailOrShowSubdomain(email, showSubdomain);
-            if (show.isPresent()) {
+            if (this.showRepository.findByEmailCollation(email).isPresent()
+                    || this.showRepository.findByShowSubdomain(showSubdomain).isPresent()) {
                 throw new RuntimeException(StatusResponse.SHOW_EXISTS.name());
             }
             String showToken = this.validateShowToken(RandomUtil.generateToken(25));

--- a/src/main/java/com/remotefalcon/controlpanel/service/ScheduledTaskService.java
+++ b/src/main/java/com/remotefalcon/controlpanel/service/ScheduledTaskService.java
@@ -2,7 +2,9 @@ package com.remotefalcon.controlpanel.service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.remotefalcon.controlpanel.repository.ShowRepository;
 import com.remotefalcon.library.documents.Notification;
@@ -10,6 +12,8 @@ import com.remotefalcon.library.documents.Show;
 import com.remotefalcon.library.enums.NotificationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,6 +23,7 @@ public class ScheduledTaskService {
     private final ShowRepository showRepository;
     private final ExpoNotificationService expoNotificationService;
     private final GraphQLMutationService graphQLMutationService;
+    private final MongoTemplate mongoTemplate;
 
     public void fppHeartbeatTask() {
         List<Show> showsToNotify = showRepository.findByPreferencesNotificationPreferencesEnableFppHeartbeatIsTrueAndLastFppHeartbeatBefore(LocalDateTime.now().minusMinutes(5));
@@ -49,5 +54,34 @@ public class ScheduledTaskService {
                 log.info("Sent FPP heartbeat notification to {}", show.getShowName());
             }
         });
+    }
+
+    /**
+     * Iterates every show via a streaming Mongo cursor and applies the 18-month
+     * stats retention policy one document at a time. Uses {@link MongoTemplate#stream}
+     * (not {@code findAll}) to avoid materializing the full collection in memory:
+     * populated show documents average ~130 KB, so 1000+ shows would otherwise
+     * exceed the control-panel pod's 512 Mi memory limit.
+     */
+    public void purgeStaleStatsForAllShows() {
+        int swept = 0;
+        int errored = 0;
+        long startMillis = System.currentTimeMillis();
+        try (Stream<Show> shows = mongoTemplate.stream(new Query(), Show.class)) {
+            Iterator<Show> it = shows.iterator();
+            while (it.hasNext()) {
+                Show show = it.next();
+                try {
+                    graphQLMutationService.purgeStatsForShow(show);
+                    swept++;
+                } catch (Exception e) {
+                    log.warn("Stats retention sweep failed for show {}: {}",
+                            show.getShowToken(), e.getMessage());
+                    errored++;
+                }
+            }
+        }
+        log.info("Stats retention sweep complete: {} shows processed, {} errored, {} ms",
+                swept, errored, System.currentTimeMillis() - startMillis);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,9 @@ management:
         allowed-origins: "*"
         allowed-methods: "OPTIONS, GET, POST, PUT, DELETE"
         allowed-headers: "*"
+  health:
+    mongo:
+      timeout: 3s
 
 sendgrid:
   mail-from: "noreply@remotefalcon.com"
@@ -41,9 +44,9 @@ mailersend:
 
 images:
   s3:
-    bucket: ${IMAGES_S3_BUCKET:remote-falcon-images}
+    bucket: ${IMAGES_S3_BUCKET:remote-falcon-uploads}
   cdn:
-    endpoint: ${IMAGES_CDN_ENDPOINT:https://remote-falcon-images.nyc3.cdn.digitaloceanspaces.com}
+    endpoint: ${IMAGES_CDN_ENDPOINT:https://remote-falcon-uploads.nyc3.cdn.digitaloceanspaces.com}
 
 logging:
   level:


### PR DESCRIPTION
Bundles four post-cutover hardening changes that close the "Known gaps" list from the 2026-05-04 audit. Each commit is a focused concern; bundling into one PR cuts the deploy + review ceremony for solo workflow. Supersedes #75, #76, #77, #78.

## Commits

### 1. \`feat(bootstrap): ensure Show collection indexes on startup\` (was #75)

Adds \`MongoIndexInitializer\` \`@Component\` hooked to \`ApplicationReadyEvent\` that calls \`MongoTemplate#indexOps(Show.class).ensureIndex(...)\` for the two production indexes:

- \`idx_showToken\` (unique on \`showToken\`) — backs every authenticated lookup.
- \`idx_email_ci\` (unique on \`email\` with collation \`{ locale: "en", strength: 2 }\`) — backs \`findByEmailCollation\` (introduced in #73).

Today these are applied imperatively via \`mongosh\`. Fresh environments come up silently unindexed until someone re-runs the script. \`ensureIndex\` is idempotent: creates if missing, no-ops if spec matches, throws on spec mismatch (caught and logged at error level — no crash-loop). The two specs match the live cluster exactly, so first deploy is a pure verification.

### 2. \`feat(retention): scheduled 18-month stats sweep at 3am UTC\` (was #76)

Restores Phase 4 of PERF-FIX-PLAN. Phase 1 (UI #67) removed the dashboard-mount \`purgeStats\` trigger; this resumes retention enforcement on a backend cron.

- New \`@Scheduled(cron = "0 0 3 * * ?")\` in \`ScheduledTaskController\` delegates to \`ScheduledTaskService.purgeStaleStatsForAllShows\`.
- \`purgeStaleStatsForAllShows\` uses \`mongoTemplate.stream(new Query(), Show.class)\` inside try-with-resources to iterate one show at a time. Populated shows average ~130 KB; \`findAll()\` would materialize ~130 MB at 1000+ shows and OOM-kill the 512 Mi pod.
- Per-show errors are logged and counted but don't abort the sweep.
- Refactored \`GraphQLMutationService.purgeStats\` to extract a shared \`purgeStatsForShow(Show)\` method called by both the existing admin mutation and the new sweep. If-changed-save optimization avoids unnecessary writes when nothing was trimmed.
- Estimated wall time today: ~8 minutes for 1000 shows (Mongo public-routing bug ~250ms/RTT). After private routing is restored: <30s. Runs at 03:00 UTC, well outside peak.

### 3. \`feat(config): tighten Mongo health probe to 3s and update bucket defaults\` (was #77)

Two YAML hardening changes to \`application.yml\`:

- **Mongo health probe timeout 30s → 3s** via \`management.health.mongo.timeout: 3s\`. Prevents a Mongo blip from cascading every replica to unready in lockstep.
- **Bucket fallback defaults**: \`remote-falcon-images\` → \`remote-falcon-uploads\`. Prod is unaffected (k8s manifest overrides via env), but local dev and any future env that forgets the env block falls back to the right bucket. Once the old bucket is deleted, the defaults stop being a 500-on-upload time-bomb.

### 4. \`feat(signup): case-insensitive email uniqueness check\` (was #78)

The signup duplicate-email pre-check used case-sensitive \`findByEmailOrShowSubdomain\`, but the live \`idx_email_ci\` Mongo unique index is case-insensitive. Mismatch meant \`Foo@example.com\` vs \`foo@example.com\` passed the application check, then failed at the DB write with a generic 500 from \`DuplicateKeyException\`.

Splits the pre-check into a case-insensitive email lookup (\`findByEmailCollation\`, uses \`idx_email_ci\`) plus a subdomain lookup (\`findByShowSubdomain\`). Now returns clean \`SHOW_EXISTS\` for case-variant duplicate emails. Drops the now-orphaned \`findByEmailOrShowSubdomain\` repository method.

## Cumulative diff

\`\`\`
.../configuration/MongoIndexInitializer.java       | 66 +++++++++++++++++++++
.../controlpanel/repository/ShowRepository.java    |  1 -
.../scheduler/ScheduledTaskController.java         | 11 +++
.../service/GraphQLMutationService.java            | 36 ++++++++----
.../controlpanel/service/ScheduledTaskService.java | 34 +++++++++++
src/main/resources/application.yml                 |  7 ++-
6 files changed, 142 insertions(+), 13 deletions(-)
\`\`\`

## Test plan

- [ ] \`mvn compile\` (verified for #75 in maven:3.9-eclipse-temurin-21 container).
- [ ] \`./dev-up.sh up mongo control-panel\` on a fresh \`mongo-data\` volume; tail logs for \`Show collection indexes ensured in <N> ms\`; verify both indexes via \`db.show.getIndexes()\`.
- [ ] Restart pod; confirm second invocation logs success without recreating indexes.
- [ ] Sign up with \`Foo@example.com\`, then attempt second signup with \`foo@example.com\` → expect clean \`SHOW_EXISTS\` error (not 500).
- [ ] Manually invoke the \`purgeStats\` GraphQL mutation as a logged-in user → expect existing behavior preserved (regression check on the refactor).
- [ ] Temporarily change the retention cron to a near-future minute, watch for \`Stats retention sweep complete: ... shows processed\` log line, then revert.
- [ ] \`kubectl top pod -n remote-falcon\` during a sweep → memory stays within 512 Mi.
- [ ] \`/actuator/health\` returns 200 on the new 3s Mongo timeout.